### PR TITLE
fix: normalize hotspot scores across platforms for fair sorting

### DIFF
--- a/scripts/fetch_hotspots.py
+++ b/scripts/fetch_hotspots.py
@@ -144,8 +144,21 @@ def main():
             sources_fail.append(name)
 
     all_items = deduplicate(all_items)
-    # Normalize hot values for sorting (different scales across sources)
-    all_items.sort(key=lambda x: int(x.get("hot", 0) or 0), reverse=True)
+
+    # Normalize hot values across platforms (different scales: toutiao ~10M, weibo ~1M, baidu ~100K)
+    # Strategy: within each source, rank-based score 0-100, so cross-platform sorting is fair
+    by_source: dict[str, list[dict]] = {}
+    for item in all_items:
+        by_source.setdefault(item["source"], []).append(item)
+
+    for source, items in by_source.items():
+        items.sort(key=lambda x: int(x.get("hot", 0) or 0), reverse=True)
+        n = len(items)
+        for rank, item in enumerate(items):
+            # Top item = 100, linear decay to ~1 for last item
+            item["hot_normalized"] = round(100 * (n - rank) / n, 1) if n > 0 else 0
+
+    all_items.sort(key=lambda x: x.get("hot_normalized", 0), reverse=True)
     all_items = all_items[:args.limit]
 
     tz = timezone(timedelta(hours=8))


### PR DESCRIPTION
## Summary
- **Problem**: `fetch_hotspots.py` sorted hotspots by raw `hot` values, but platforms use vastly different scales (Toutiao ~10M, Weibo ~1M, Baidu ~100K). This caused Toutiao to dominate all results, while Weibo and Baidu entries were always truncated.
- **Fix**: Rank-based normalization (0-100) within each source before merging, so cross-platform sorting gives equal weight to each platform's top stories.
- Adds `hot_normalized` field to each item for transparent scoring.

## Test plan
- [x] Verified output now interleaves all 3 sources fairly
- [x] `--limit` still works correctly after normalization

🤖 Generated with [Claude Code](https://claude.com/claude-code)