### PR TITLE
fix: add --digest to publish command in SKILL.md

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -237,9 +237,11 @@ WebSearch: "{选题关键词} 数据 报告 2025 2026"
 
 Converter 自动处理：CJK 加空格、加粗标点外移、列表转 section、外链转脚注、暗黑模式、容器语法。
 
+**重要**：必须用 `--digest` 传入 Step 5 生成的摘要，否则 cli.py 会截取文章开头作为摘要，导致分享卡片显示不佳。
+
 ```bash
 # 发布
-python3 {skill_dir}/toolkit/cli.py publish {markdown} --cover {cover} --theme {theme} --title "{title}"
+python3 {skill_dir}/toolkit/cli.py publish {markdown} --cover {cover} --theme {theme} --title "{title}" --digest "{Step 5 生成的摘要}"
 
 # 降级：本地预览
 python3 {skill_dir}/toolkit/cli.py preview {markdown} --theme {theme} --no-open -o {output}.html


### PR DESCRIPTION
## Summary

- Add `--digest` parameter to the publish command template in Step 7
- Add note explaining why `--digest` is important (prevents poor share-card previews)

## Problem

Step 5 generates a proper digest (≤54 chars), but the publish command in Step 7 was missing `--digest`, so `cli.py` fell back to truncating the article's opening paragraph. This produces poor WeChat share-card previews because the opening is often a narrative hook, not a summary.

## Fix

```diff
-python3 {skill_dir}/toolkit/cli.py publish {markdown} --cover {cover} --theme {theme} --title "{title}"
+python3 {skill_dir}/toolkit/cli.py publish {markdown} --cover {cover} --theme {theme} --title "{title}" --digest "{Step 5 生成的摘要}"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)