### PR TITLE
fix: publish 命令支持 --digest 覆盖自动摘要

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -177,7 +177,7 @@ WebSearch: "{选题关键词} 数据 报告 2025 2026"
 读取: {skill_dir}/references/seo-rules.md
 ```
 
-**5a. SEO**：3 个备选标题 + 摘要（≤54 字）+ 5 标签 + 关键词密度优化
+**5a. SEO**：3 个备选标题 + 摘要（≤40 字）+ 5 标签 + 关键词密度优化
 
 **5b. 去 AI 逐层验证**（writing-guide.md 自检清单，每项必须通过）：
 
@@ -237,11 +237,9 @@ WebSearch: "{选题关键词} 数据 报告 2025 2026"
 
 Converter 自动处理：CJK 加空格、加粗标点外移、列表转 section、外链转脚注、暗黑模式、容器语法。
 
-**重要**：必须用 `--digest` 传入 Step 5 生成的摘要，否则 cli.py 会截取文章开头作为摘要，导致分享卡片显示不佳。
-
 ```bash
 # 发布
-python3 {skill_dir}/toolkit/cli.py publish {markdown} --cover {cover} --theme {theme} --title "{title}" --digest "{Step 5 生成的摘要}"
+python3 {skill_dir}/toolkit/cli.py publish {markdown} --cover {cover} --theme {theme} --title "{title}" --digest "{digest}"
 
 # 降级：本地预览
 python3 {skill_dir}/toolkit/cli.py preview {markdown} --theme {theme} --no-open -o {output}.html

--- a/SKILL.md
+++ b/SKILL.md
@@ -237,9 +237,11 @@ WebSearch: "{选题关键词} 数据 报告 2025 2026"
 
 Converter 自动处理：CJK 加空格、加粗标点外移、列表转 section、外链转脚注、暗黑模式、容器语法。
 
+**重要**：必须用 `--digest` 传入 Step 5 生成的摘要，否则 cli.py 会截取文章开头作为摘要，导致分享卡片显示不佳。
+
 ```bash
 # 发布
-python3 {skill_dir}/toolkit/cli.py publish {markdown} --cover {cover} --theme {theme} --title "{title}"
+python3 {skill_dir}/toolkit/cli.py publish {markdown} --cover {cover} --theme {theme} --title "{title}" --digest "{Step 5 生成的摘要}"
 
 # 降级：本地预览
 python3 {skill_dir}/toolkit/cli.py preview {markdown} --theme {theme} --no-open -o {output}.html

--- a/toolkit/cli.py
+++ b/toolkit/cli.py
@@ -121,7 +121,7 @@ def cmd_publish(args):
 
     # Create draft
     title = args.title or result.title or Path(args.input).stem
-    digest = result.digest
+    digest = args.digest or result.digest
     draft = create_draft(
         access_token=token,
         title=title,
@@ -379,6 +379,7 @@ def main():
     p_publish.add_argument("--cover", help="Cover image file path")
     p_publish.add_argument("--title", help="Override article title")
     p_publish.add_argument("--author", default=None, help="Article author")
+    p_publish.add_argument("--digest", default=None, help="Override article digest (≤120 UTF-8 bytes)")
 
     # themes
     sub.add_parser("themes", help="List available themes")


### PR DESCRIPTION
## Summary

- `cli.py publish` 新增 `--digest` 参数，传入则优先使用，否则回退 converter 自动截取
- SKILL.md Step 5 摘要限制从 ≤54 字改为 ≤40 字（对齐微信 API 120 UTF-8 字节限制）
- SKILL.md Step 7 命令模板补上 `--digest`

## Problem

Step 5 让 AI 生成精炼摘要，但 Step 7 的 publish 命令没有传递它。`cli.py` 只用 converter 截取文章开头 120 字节作为摘要，导致微信分享卡片显示不佳。

原始问题由 @ystyleb 在 #5 中发现，本 PR 在其基础上补全了 cli.py 的改动。

## Test plan

- [ ] `python3 toolkit/cli.py publish test.md --digest "自定义摘要"` 使用传入的摘要
- [ ] `python3 toolkit/cli.py publish test.md`（不传 --digest）回退自动截取，行为不变

🤖 Generated with [Claude Code](https://claude.com/claude-code)