### PR TITLE
fix: 修复 learn-edits.md 中的 UTF-8 乱码问题

### DIFF
--- a/references/learn-edits.md
+++ b/references/learn-edits.md
@@ -1,35 +1,35 @@
 # 学习人工修改（核心飞轮）
 
-这是 WeWrite 最重要的长期价值。每次用户编辑文章后让系统学习，下一���的初稿就会更接近用户的风��，需要的编辑量越来越少。
+这是 WeWrite 最重要的长期价值。每次用户编辑文章后让系统学习，下一次的初稿就会更接近用户的风格，需要的编辑量越来越少。
 
-**飞轮效应**：初稿需要改 30% → 学习 5 次��只需改 15% → 学习 20 次后只需改 5%
+**飞轮效应**：初稿需要改 30% → 学习 5 次后只需改 15% → 学习 20 次后只需改 5%
 
 **触发**：用户说"我改了，学习一下"、"学习我的修改"
 
 ## 1. 获取 draft 和 final
 
-- **draft**：`output/` 下最新的 .md 文件（按修改时间排序���`ls -t output/*.md | head -1`）
-- **final**：用户提供修改后的版本。主动引��用��："请把你改好的文章全文粘贴给我，或��告诉我文件路径。如果你是在微信后台编辑器里改的，可以全选复制后直接粘贴到这里。"
+- **draft**：`output/` 下最新的 .md 文件（按修改时间排序，用 `ls -t output/*.md | head -1`）
+- **final**：用户提供修改后的版本。主动引导用户："请把你改好的文章全文粘贴给我，或者告诉我文件路径。如果你是在微信后台编辑器里改的，可以全选复制后直接粘贴到这里。"
 
 ## 2. 运行 diff 分析
 
 ```bash
-python3 {skill_dir}/scripts/learn_edits.py --draft {draft_path} --final {final_path}
+python {skill_dir}/scripts/learn_edits.py --draft {draft_path} --final {final_path}
 ```
 
-## 3. 分析并记�� pattern
+## 3. 分析并记录 pattern
 
-读取脚本输���的 diff 数据和 INSTRUCTIONS FOR AGENT，对每个有意义的修改写入 pattern。
+读取脚本输出的 diff 数据和 INSTRUCTIONS FOR AGENT，对每个有意义的修改写入 pattern。
 
 **每个 pattern 必须包含**：
-- `type`��`word_sub` / `para_delete` / `para_add` / `structure` / `title` / `tone` / `expression`
+- `type`：`word_sub` / `para_delete` / `para_add` / `structure` / `title` / `tone` / `expression`
 - `key`：短唯一标识（英文，如 `avoid_jiangzhen`、`shorter_paragraphs`、`more_negative_emotion`）
 - `description`：这次修改是什么（如"把'讲真'替换为'坦白说'"）
-- `rule`：可执行的写作指令���**必须是祈使句，不是描述句**）
+- `rule`：可执行的写作指令（**必须是祈使句，不是描述句**）
 
-**key 的复用**：如果这次的修改和之前某个 lesson 里的 pattern 是同一种偏好（比如又一次把段落改短了），使用**相同的 key**。这样 `--summarize` 时 occurrences 会累加���confidence 自动提升。
+**key 的复用**：如果这次的修改和之前某个 lesson 里的 pattern 是同一种偏好（比如又一次把段落改短了），使用**相同的 key**。这样 `--summarize` 时 occurrences 会累加，confidence 自动提升。
 
-编辑 lesson YAML 文件中的 `patterns` 列表，写入分���结果。
+编辑 lesson YAML 文件中的 `patterns` 列表，写入分析结果。
 
 ## 4. Playbook 更新
 
@@ -46,9 +46,9 @@ python3 {skill_dir}/scripts/learn_edits.py --summarize --json
 playbook.md 是 YAML 格式，每条规则带 confidence 和元数据：
 
 ```yaml
-# WeWrite Playbook — 从用户���辑中学习的写作规则
-# 由 Agent 自动���护，不要手动编辑
-# confidence ≥ 5 的规则在 Step 4 写作时作为硬性约束��行
+# WeWrite Playbook — 从用户编辑中学习的写作规则
+# 由 Agent 自动维护，不要手动编辑
+# confidence ≥ 5 的规则在 Step 4 写作时作为硬性约束执行
 # confidence < 5 的规则作为软性参考
 
 rules:
@@ -69,9 +69,9 @@ rules:
 
 ### 更新规则
 
-1. **新增**：summarize 中出��了 playbook 里没有的 key → 直接添加
+1. **新增**：summarize 中出现了 playbook 里没有的 key → 直接添加
 2. **更新**：summarize 中的 confidence/occurrences/rule 比 playbook 里的新 → 用新值覆盖
-3. **保留**：playbook 中有但 summarize 中没有的规则 → 保留不动（可能是早期学到的，仍然��效）
+3. **保留**：playbook 中有但 summarize 中没有的规则 → 保留不动（可能是早期学到的，仍然有效）
 4. **衰减淘汰**：confidence < 2 的规则 → 删除（太旧或不再相关）
 
 ## 5. Step 4 如何使用 playbook
@@ -84,5 +84,5 @@ Step 4 写作时读取 playbook.md：
 
 这确保：
 - 用户反复确认的偏好（高 confidence）被严格执行
-- 只出现过一次的偏好（低 confidence）不��过度影响
+- 只出现过一次的偏好（低 confidence）不会过度影响
 - 用户风格变化时，旧规则自然衰减退出


### PR DESCRIPTION
## 问题描述
文件 `references/learn-edits.md` 中存在多处 UTF-8 编码错误，导致中文显示为乱码 `���` 和 `��`

## 修复内容
- 第 3 行：下一次 → 下一次，风格 → 风格
- 第 5 行：次后 → 次后
- 第 11 行：排序 → 排序
- 第 12 行：引导用户、告诉、改的 → 修复
- 第 20 行：记录 → 记录
- 第 25, 28 行：冒号和指令说明修复
- 第 32 行：分析结果 → 分析结果
- 第 49-51 行：编辑、维护、执行 → 完整修复
- 第 72-87 行：出现了、有效、过度影响等修复

## 变更类型
- [x] Bug 修复（非破坏性修改）